### PR TITLE
Fix issue #1: Avoid the relative path problem by embedding the image

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,7 +255,6 @@ fn download_puml_svg(puml_str: &str) -> String
     let compressed = deflate_bytes(puml_str.as_bytes());
     let encode64_str = save_http_png::encode64_(&compressed);
     let url = "http://www.plantuml.com/plantuml/svg/".to_string() + &encode64_str;
-    println!("plantuml url -> {}", url);
   
     let agent = ureq::AgentBuilder::new()
     .timeout_read(Duration::from_secs(5))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,7 +163,7 @@ fn save_plantuml(uml_str:&str) -> String{
 
     if svg.len() > 0 {
         println!("svg response {}", svg);
-        output.push_str(&("</p>".to_string() + svg.as_str()));
+        output.push_str(&("</p><div>".to_string() + svg.as_str() + "</div>"));
     }
     else if true == save_http_png::download_puml(&uml_str, uml_file_name)
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![doc = include_str!("../README.md")]
 #![warn(rust_2018_idioms)]
+use deflate::deflate_bytes;
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, ToTokens};
 use syn::{
@@ -7,7 +8,7 @@ use syn::{
     parse::{Parse, ParseStream},
     parse_macro_input, AttrStyle, Attribute, Error, Lit, LitStr, Meta, MetaNameValue, Result,
 };
-use std::fs;
+use std::{fs, time::Duration};
 
 mod save_http_png;
 
@@ -158,7 +159,13 @@ fn save_plantuml(uml_str:&str) -> String{
     let uml_file_name = &("./target/doc/images/puml_files/".to_string() + hasher.result_str().as_str() + ".png");
     
 
-    if true == save_http_png::download_puml(&uml_str, uml_file_name)
+    let svg = download_puml_svg(&uml_str);
+
+    if svg.len() > 0 {
+        println!("svg response {}", svg);
+        output.push_str(&("</p>".to_string() + svg.as_str()));
+    }
+    else if true == save_http_png::download_puml(&uml_str, uml_file_name)
     {
         output.push_str(&("</p><img src = \"".to_string() + "../images/puml_files/" + hasher.result_str().as_str() + ".png" + "\" />\n"));
     }
@@ -242,4 +249,28 @@ fn handle_error(cb: impl FnOnce() -> Result<proc_macro::TokenStream>) -> proc_ma
         Ok(tokens) => tokens,
         Err(e) => e.to_compile_error().into(),
     }
+}
+
+fn download_puml_svg(puml_str: &str) -> String
+{
+    let compressed = deflate_bytes(puml_str.as_bytes());
+    let encode64_str = save_http_png::encode64_(&compressed);
+    let url = "http://www.plantuml.com/plantuml/svg/".to_string() + &encode64_str;
+    println!("plantuml url -> {}", url);
+  
+    let agent = ureq::AgentBuilder::new()
+    .timeout_read(Duration::from_secs(5))
+    .timeout_write(Duration::from_secs(5))
+    .build();
+
+    let ret = match agent.get(&url).call() {
+        Ok(response) => response.into_string(),
+        Err(_) => return String::default(),
+    };
+
+    match ret {
+        Ok(s) => return s,
+        Err(_) => return String::default()
+    }
+
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,6 @@ fn save_plantuml(uml_str:&str) -> String{
     let svg = download_puml_svg(&uml_str);
 
     if svg.len() > 0 {
-        println!("svg response {}", svg);
         output.push_str(&("</p><div>".to_string() + svg.as_str() + "</div>"));
     }
     else if true == save_http_png::download_puml(&uml_str, uml_file_name)

--- a/src/save_http_png.rs
+++ b/src/save_http_png.rs
@@ -63,7 +63,7 @@ fn save_png(url:&str, output_filename:&str) -> bool{
     return true;
 }
 
-fn encode64_(e:&[u8]) -> String{
+pub fn encode64_(e:&[u8]) -> String{
     let mut r = String::new();
 
     for i in (0..e.len()).step_by(3)


### PR DESCRIPTION
It seemed quite tricky to get the relative path computed properly given that the hierarchy of the html files seems to be based on the module path rather than the source path. This approach avoids the problem by embedding the image directly into the html. And I also opted for SVG format rather than base64 PNG for size reasons.

addresses issue #1 